### PR TITLE
fix: use /sec:tls everywhere

### DIFF
--- a/app-linux/src/cassowary/__init__.py
+++ b/app-linux/src/cassowary/__init__.py
@@ -111,7 +111,7 @@ def main():
                         Usage   :
                                 cassowary -c path-map -- /home/user/document/personal.docx
     """
-    BASE_RDP_CMD = '{rdc} /d:"{domain}" /u:"{user}" /p:"{passd}" /v:{ip} +clipboard /a:drive,root,{share_root} ' \
+    BASE_RDP_CMD = '{rdc} /sec:tls /d:"{domain}" /u:"{user}" /p:"{passd}" /v:{ip} +clipboard /a:drive,root,{share_root} ' \
                    '+decorations /cert-ignore /sound /scale:{scale} /dynamic-resolution /{mflag} {rdflag} ' \
                    '/wm-class:"{wmclass}" ' \
                    '/app:"{execu}" /app-icon:"{icon}" '

--- a/app-linux/src/cassowary/base/helper.py
+++ b/app-linux/src/cassowary/base/helper.py
@@ -11,7 +11,7 @@ import libvirt
 from cassowary.gui.components.vmstart import StartDg
 
 logger = get_logger(__name__)
-wake_base_cmd = 'xfreerdp /d:"{domain}" /u:"{user}" /p:"{passd}" /v:"{ip}" +clipboard /a:drive,root,{share_root} ' \
+wake_base_cmd = 'xfreerdp /sec:tls /d:"{domain}" /u:"{user}" /p:"{passd}" /v:"{ip}" +clipboard /a:drive,root,{share_root} ' \
                 '+decorations /cert-ignore /sound /scale:100 /dynamic-resolution /span  ' \
                 '/wm-class:"cassowaryApp-echo" /app:"{app}"'
 
@@ -235,7 +235,7 @@ def create_reply(message, data, status):
 
 
 def full_rdp():
-    command = '{rdc} /d:"{domain}" /u:"{user}" /p:"{passd}" /v:{ip} /a:drive,root,{share_root} +auto-reconnect ' \
+    command = '{rdc} /sec:tls /d:"{domain}" /u:"{user}" /p:"{passd}" /v:{ip} /a:drive,root,{share_root} +auto-reconnect ' \
               '+clipboard /cert-ignore /audio-mode:1 /scale:{scale} /wm-class:"cassowaryApp-FULLSESSION" ' \
               '/dynamic-resolution /{mflag} {rdflag} 1> /dev/null 2>&1 &'
     multimon_enable = int(os.environ.get("RDP_MULTIMON", cfgvars.config["rdp_multimon"]))

--- a/app-linux/src/cassowary/cli.py
+++ b/app-linux/src/cassowary/cli.py
@@ -63,7 +63,7 @@ if __name__ == "__main__":
                         Usage   :
                                 casualrdh_linux -a path-map -- /home/user/document/personal.docx
     """
-    BASE_RDP_CMD = 'xfreerdp {rdflag} /d:"{domain}" /u:"{user}" /p:"{passd}" /v:{ip} +auto-reconnect +clipboard ' \
+    BASE_RDP_CMD = 'xfreerdp {rdflag} /sec:tls /d:"{domain}" /u:"{user}" /p:"{passd}" /v:{ip} +auto-reconnect +clipboard ' \
                    '+home-drive -wallpaper /scale:{scale} /dynamic-resolution /{mflag} /wm-class:"{wmclass}" ' \
                    '/app:"{execu}" /app-icon:"{icon}"'
     parser = argparse.ArgumentParser(description=about, formatter_class=argparse.RawDescriptionHelpFormatter)


### PR DESCRIPTION
Basically, if you use xfreerdp without it, the application will just raise error ERRCONNECT_LOGON_FAILURE, and according to FreeRDP/FreeRDP#5972#issuecomment-674729392, we need to disable Allow connections only from computers running Remote Desktop with Network Level Authentication (recommended) and use /sec:tls for the connection to work. This commit add /sec:tls to all RDP commands.